### PR TITLE
0.7.91

### DIFF
--- a/Resources/Server/CobaltEssentials/extensions/CEI.lua
+++ b/Resources/Server/CobaltEssentials/extensions/CEI.lua
@@ -1034,8 +1034,10 @@ local function txData()
 	txNametagBlockerActive()
 	for player_id, player_name in pairs(MP.GetPlayers()) do
 		local player = players.getPlayerByName(player_name)
-		txPlayersGroup(player)
-		txPlayersUIPerm(player)
+		if player.connectStage == "connected" then
+			txPlayersGroup(player)
+			txPlayersUIPerm(player)
+		end
 	end
 end
 


### PR DESCRIPTION
tiny update while I think about bigger updates
fixes crashing when enabled offline
stopped injecting and uninjecting ui apps until I feel like doing it a better way. (if the race countdown app is manually present, it will still display, otherwise only the audio cue plays.
handles server plugin paths better (-master ....)
I turned off the console and editor lockout thing until I build those in proper to the interface in the global restrictions section, which I hope to take care of soon.